### PR TITLE
AG | Cleanup for launch

### DIFF
--- a/src/main/modules/stripe.js
+++ b/src/main/modules/stripe.js
@@ -36,7 +36,7 @@ export const toCharge = d => ({
   amount: d.amount,
   currency: "usd",
   source: d.token,
-  description: "Riseup Labs Donation"
+  description: "Donation to Where@"
 });
 
 // (Donation) -> Promise[Donation]

--- a/src/main/routes/donations.js
+++ b/src/main/routes/donations.js
@@ -24,10 +24,7 @@ import { charge } from '../modules/stripe';
 import { assign } from 'lodash';
 const r = express.Router();
 
-const sendErr = (err, resp) => {
-  console.log('Error processing donation: ', err);
-  resp.status(500).json({ error: err });
-};
+const sendErr = (err, resp) => resp.status(500).json({ error: err });
 
 assign(r, {
   charge: charge,

--- a/src/test/modules/stripe.spec.js
+++ b/src/test/modules/stripe.spec.js
@@ -76,7 +76,7 @@ describe('Stripe module', () => {
             amount: ds[0].amount,
             currency: "usd",
             source: ds[0].token,
-            description: "Riseup Labs Donation"
+            description: "Donation to Where@"
           });
         });
       });


### PR DESCRIPTION
- remove console.log-ing of errors
  (purpose was to make errors inspectable, but they are, via debugging
  tools inspecting HTTP response)
- replace reference to Riseup Lab donations
  (current form pays directly to TLTP)
