### PR TITLE
[#12] AG | Handle commas in donation amount field

### DIFF
--- a/src/main/models/donation/parse.js
+++ b/src/main/models/donation/parse.js
@@ -29,11 +29,14 @@ export const parse = d =>
   Promise.resolve( assign({},d, { amount: toCents(d.amount) }) ) :
   Promise.reject( new Error(nonDollarMsg(d)) ); 
 
+// (String) -> String
+const stripCommas = str => str.replace(/,/g, '');
+
 // (Either[String, Number]) ->  Number
 export const toCents = amt => {
   switch(typeof amt) {
   case 'string':
-    const matches = matchesDollarPattern(amt);
+    const matches = matchesDollarPattern(stripCommas(amt));
     return !matches ? 0 : parseInt(matches[2]) * 100 + (parseInt(matches[4]) || 0);
   default:
     return amt * 100;

--- a/src/test/models/donation/parse.spec.js
+++ b/src/test/models/donation/parse.spec.js
@@ -42,7 +42,7 @@ describe('Donation parse module', () => {
 
   describe('#toCents', () => {
 
-    it('converts dollar strings to cent integers', () => {
+    it.only('converts dollar strings to cent integers', () => {
 
       toCents(100).should.equal(10000);
       toCents(100.00).should.equal(10000);
@@ -58,6 +58,8 @@ describe('Donation parse module', () => {
       toCents('$100.000').should.equal(10000);
       toCents(' 100 ').should.equal(10000);
       toCents(' 100.00 ').should.equal(10000);
+
+      toCents('$1,000,000.00').should.equal(100000000);
       
       toCents('foobar').should.equal(0);
     });


### PR DESCRIPTION
- Bug: donations with commas are interpreted as $0
- Cause: `donation.parse#toCents` doesn't handle commas
- Fix: strip commas from input before passing to regex matcher
